### PR TITLE
MAKE-1329: Create deployable C extension

### DIFF
--- a/.github/workflows/publishpackage.yml
+++ b/.github/workflows/publishpackage.yml
@@ -1,0 +1,20 @@
+name: Publish Python Package
+
+on: 
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Publish Package
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build and Publish Python Package
+      uses: ./  # Use action in the root directory.
+      id: publish
+      with:
+        pypi-username: ${{ secrets.PYPI_USERNAME }}
+        pypi-password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/publishpackage.yml
+++ b/.github/workflows/publishpackage.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Publish Package
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM quay.io/pypa/manylinux1_x86_64
+
+RUN /opt/python/cp37-cp37m/bin/pip install poetry
+
+RUN mkdir signal_processing
+ADD . signal_processing
+
+WORKDIR signal_processing
+
+ENTRYPOINT ["/signal_processing/scripts/deploy.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM quay.io/pypa/manylinux1_x86_64
 
 RUN /opt/python/cp37-cp37m/bin/pip install poetry
 
-RUN mkdir signal_processing
 ADD . signal_processing
 
 WORKDIR signal_processing

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,15 @@
+name: "Build and Publish Python Package"
+description: "Build and publish a python package with C extension support"
+inputs:
+  pypi-username: 
+    description: Username of Pypi account to publish to.
+    required: true
+  pypi-password:
+    description: Password of Pypi account to publish to.
+    required: true
+runs:
+  using: docker
+  image: Dockerfile
+  env: 
+    PYPI_USERNAME: ${{ inputs.pypi-username }}
+    PYPI_PASSWORD: ${{ inputs.pypi-password }}

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -5,7 +5,6 @@ buildvariants:
       - ubuntu1604-test
     tasks:
       - name: unit_tests
-      - name: deploy
 functions:
   create virtualenv:
     - command: shell.exec
@@ -19,20 +18,6 @@ functions:
           . venv/bin/activate
           pip install poetry
           poetry install
-  deploy:
-    - command: shell.exec
-      params:
-        working_dir: project
-        script: |
-          set -o errexit
-          . venv/bin/activate
-
-          if [ "${is_patch}" = "true" ]; then
-            # Do not deploy on patches.
-            exit 0
-          fi
-
-          poetry publish --build --username ${pypi_user} --password ${pypi_password}
 pre:
   - command: git.get_project
     params:
@@ -51,9 +36,3 @@ tasks:
           script: |
             . venv/bin/activate
             poetry run pytest --junitxml=test_output_junit.xml
-  - name: deploy
-    depends_on:
-      - name: unit_tests
-    patchable: false
-    commands:
-      - func: deploy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "signal-processing-algorithms"
-version = "1.2.1"
+version = "1.2.2"
 description = "Signal Processing Algorithms from MongoDB"
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+# This uses 'manylinux' docker image and 'auditwheel' to ensure our c extension
+# works on lots of linux platforms without needing to be recompiled. The image
+# provides toolchain for various version. We will be using the 3.7 version which
+# is at the path below.
+#
+# For more information see: https://github.com/pypa/auditwheel
+export PATH="$PATH:/opt/python/cp37-cp37m/bin"
+
+poetry build
+find ./dist -name "*.whl" | xargs auditwheel repair
+rm dist/*.whl
+mv wheelhouse/* dist
+echo poetry publish --username $PYPI_USERNAME --password $PYPI_PASSWORD

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,4 +14,4 @@ poetry build
 find ./dist -name "*.whl" | xargs auditwheel repair
 rm dist/*.whl
 mv wheelhouse/* dist
-echo poetry publish --username $PYPI_USERNAME --password $PYPI_PASSWORD
+poetry publish --username $PYPI_USERNAME --password $PYPI_PASSWORD


### PR DESCRIPTION
The deploy is failing because pypi wants C extensions to be build in a minimalistic environment that can easily be deployed to lots of Linux environments without needing to be recompiled (see PEP 513).  They also provide a Docker image with that environment on it that you can use to build everything. But, since Evergreen doesn't have great Docker support, using the image in Evergreen would be a challenge right now.

Instead, I've written up a Github Action that will build and publish the library from the Docker image whenever a change is pushed to master. This should get us back to where we were before.