### PR TITLE
DAG-2764 Update dockerfile for publish.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM quay.io/pypa/manylinux2010_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64
 
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN /opt/python/cp38-cp38/bin/pip install poetry
 
 ADD . signal_processing


### PR DESCRIPTION
The [attempted publish](https://github.com/mongodb/signal-processing-algorithms/actions/runs/5742197499/job/15564494193) failed. 

I made updates to move to a newer image and install cargo to fix the errors. I successfully ran docker build locally with these changes.