### PR TITLE
DAG-2764 Pin poetry version in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/pypa/manylinux2014_x86_64
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN /opt/python/cp38-cp38/bin/pip install poetry
+RUN /opt/python/cp38-cp38/bin/pip install poetry==1.3.2
 
 ADD . signal_processing
 


### PR DESCRIPTION
Pinning the poetry version seemed to work locally, see the output below.

```
(signal-processing-algorithms-py3.9) ➜  signal-processing-algorithms git:(DAG-2764) docker run sha256:99b164b8abed873eb1b3fac2a07af5689c1c307846ab290e7da9f53ee1491174
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Creating virtualenv signal-processing-algorithms-OUBYNykL-py3.8 in /root/.cache/pypoetry/virtualenvs

Preparing build environment with build-system requirements setuptools, wheelBuilding signal-processing-algorithms (2.1.0)
running build
running build_py
creating /signal_processing/build
creating /signal_processing/build/lib.linux-x86_64-cpython-38
creating /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms
copying src/signal_processing_algorithms/gesd.py -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms
copying src/signal_processing_algorithms/__init__.py -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms
copying src/signal_processing_algorithms/determinism.py -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms
creating /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms/energy_statistics
copying src/signal_processing_algorithms/energy_statistics/energy_statistics.py -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms/energy_statistics
copying src/signal_processing_algorithms/energy_statistics/__init__.py -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms/energy_statistics
copying src/signal_processing_algorithms/energy_statistics/cext_calculator.py -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms/energy_statistics
copying src/signal_processing_algorithms/energy_statistics/e_divisive.c -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms/energy_statistics
copying src/signal_processing_algorithms/energy_statistics/_e_divisive.cpython-39-darwin.so -> /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms/energy_statistics
running build_ext
building 'signal_processing_algorithms.energy_statistics._e_divisive' extension
creating /signal_processing/build/temp.linux-x86_64-cpython-38
creating /signal_processing/build/temp.linux-x86_64-cpython-38/src
creating /signal_processing/build/temp.linux-x86_64-cpython-38/src/signal_processing_algorithms
creating /signal_processing/build/temp.linux-x86_64-cpython-38/src/signal_processing_algorithms/energy_statistics
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/tmp/tmpk_tyoumg/.venv/include -I/opt/_internal/cpython-3.8.17/include/python3.8 -c ./src/signal_processing_algorithms/energy_statistics/e_divisive.c -o /signal_processing/build/temp.linux-x86_64-cpython-38/./src/signal_processing_algorithms/energy_statistics/e_divisive.o -O3
gcc -pthread -shared /signal_processing/build/temp.linux-x86_64-cpython-38/./src/signal_processing_algorithms/energy_statistics/e_divisive.o -o /signal_processing/build/lib.linux-x86_64-cpython-38/signal_processing_algorithms/energy_statistics/_e_divisive.cpython-38-x86_64-linux-gnu.so -shared
INFO:auditwheel.main_repair:Repairing signal_processing_algorithms-2.1.0-cp38-cp38-manylinux_2_17_x86_64.whl
INFO:auditwheel.main_repair:Wheel is eligible for a higher priority tag. You requested manylinux2014_x86_64 but I have found this wheel is eligible for manylinux_2_5_x86_64.
INFO:auditwheel.wheeltools:Previous filename tags: manylinux_2_17_x86_64
INFO:auditwheel.wheeltools:New filename tags: manylinux_2_17_x86_64, manylinux_2_5_x86_64, manylinux1_x86_64, manylinux2014_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp38-cp38-manylinux_2_17_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp38-cp38-manylinux_2_17_x86_64, cp38-cp38-manylinux_2_5_x86_64, cp38-cp38-manylinux1_x86_64, cp38-cp38-manylinux2014_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /signal_processing/wheelhouse/signal_processing_algorithms-2.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl
```